### PR TITLE
Always run check version command

### DIFF
--- a/tasks/install-python.yml
+++ b/tasks/install-python.yml
@@ -3,6 +3,7 @@
   shell: /usr/local/bin/python3 --version |sed 's/^Python //'
   register: python_version_current
   changed_when: 'python_version_current.stdout != python_version_default'
+  check_mode: no
 
 - block:
   - name: "Download python {{ python_version_default }} source code"


### PR DESCRIPTION
When executed with '--check' option, version check command skipped.
And failed to compaire result with current version check.